### PR TITLE
Allow avax path only

### DIFF
--- a/src/common/bip32.c
+++ b/src/common/bip32.c
@@ -182,20 +182,21 @@ bool is_address_path_standard(const uint32_t *bip32_path,
     return true;
 }
 
+// The BTC integration is specifically modified for avax's WPKH (wpkh(@1/**))
+// where the only allow root path is '44/'60/'n so
+// To prevent misuse, we error for any other
+// path purpose.
 int get_bip44_purpose(int address_type) {
     switch (address_type) {
-        case ADDRESS_TYPE_LEGACY:
-            return 44;  // legacy
-        // case ADDRESS_TYPE_WIT:
-        //     return 84;  // native segwit
-        // avax's team wants to support m/44' for 
-        // pwkh() policies
+        // case ADDRESS_TYPE_LEGACY:
+        //     return 44;  // legacy
         case ADDRESS_TYPE_WIT:
-            return 44;  // native segwit
-        case ADDRESS_TYPE_SH_WIT:
-            return 49;  // wrapped segwit
-        case ADDRESS_TYPE_TR:
-            return 86;  // taproot
+            // return 84;  // native segwit
+            return 44;  // native segwit(changed to 44)
+        // case ADDRESS_TYPE_SH_WIT:
+        //     return 49;  // wrapped segwit
+        // case ADDRESS_TYPE_TR:
+        //     return 86;  // taproot
         default:
             return -1;
     }

--- a/src/handler/get_extended_pubkey.c
+++ b/src/handler/get_extended_pubkey.c
@@ -108,11 +108,11 @@ static bool is_path_safe_for_pubkey_export(const uint32_t bip32_path[],
         uint32_t script_type = bip32_path[3] & 0x7FFFFFFF;
         if (script_type != 1 && script_type != 2) {
             return false;
-            }
         }
-
-        return true;
     }
+
+    return true;
+}
 
 void handler_get_extended_pubkey(dispatcher_context_t *dc, uint8_t protocol_version) {
     (void) protocol_version;
@@ -143,8 +143,12 @@ void handler_get_extended_pubkey(dispatcher_context_t *dc, uint8_t protocol_vers
         return;
     }
 
-    uint32_t coin_types[3] = {BIP44_COIN_TYPE, BIP44_COIN_TYPE_2, BIP44_COIN_TYPE_3};
-    bool is_safe = is_path_safe_for_pubkey_export(bip32_path, bip32_path_len, coin_types, sizeof(coin_types)/ sizeof(uint32_t));
+    // Allow only 44'/60'/x
+    uint32_t coin_types[1] = {BIP44_COIN_TYPE_3};
+    bool is_safe = is_path_safe_for_pubkey_export(bip32_path,
+                                                  bip32_path_len,
+                                                  coin_types,
+                                                  sizeof(coin_types) / sizeof(uint32_t));
 
     if (!is_safe && !display) {
         SEND_SW(dc, SW_NOT_SUPPORTED);

--- a/src/handler/get_wallet_address.c
+++ b/src/handler/get_wallet_address.c
@@ -205,7 +205,8 @@ void handler_get_wallet_address(dispatcher_context_t *dc, uint8_t protocol_versi
             return;
         }
 
-        uint32_t coin_types[3] = {BIP44_COIN_TYPE, BIP44_COIN_TYPE_2, BIP44_COIN_TYPE_3};
+        // Allow only 44'/60'/x
+        uint32_t coin_types[1] = {BIP44_COIN_TYPE_3};
 
         uint32_t bip32_path[5];
         for (int i = 0; i < 3; i++) {

--- a/src/handler/sign_psbt.c
+++ b/src/handler/sign_psbt.c
@@ -679,8 +679,9 @@ init_global_state(dispatcher_context_t *dc, sign_psbt_state_t *st) {
                 }
             }
 
-            uint32_t coin_types[3] = {BIP44_COIN_TYPE, BIP44_COIN_TYPE_2, BIP44_COIN_TYPE_3};
-            uint32_t coin_types_len = sizeof(coin_types)/ sizeof(uint32_t);
+            // Allow only 44'/60'/x
+            uint32_t coin_types[1] = {BIP44_COIN_TYPE_3};
+            uint32_t coin_types_len = sizeof(coin_types) / sizeof(uint32_t);
             if (key_info.master_key_derivation_len != 3 ||
                 !is_pubkey_path_standard(key_info.master_key_derivation,
                                          key_info.master_key_derivation_len,


### PR DESCRIPTION
These changes ensure that the BTC-integration works only with the avalanche path.